### PR TITLE
Add warmup + http2, and also lowered the number of connections

### DIFF
--- a/benchmarks/run_bench.sh
+++ b/benchmarks/run_bench.sh
@@ -66,7 +66,10 @@ project_bin="${project_name}-${duration}s-${workers}w-${targets}.bin"
 project_report="${project_name}-${duration}s-${workers}w-${targets}.report"
 
 python3 monitor_process.py $duration $server_pid > data/$project_csv &
-cat $targets_file | vegeta attack -duration=${duration}s -rate=0 -max-workers=${workers} > data/$project_bin
+# warm up
+cat $targets_file | vegeta attack -http2 -duration=10s -rate=0 -max-workers=${workers} > /dev/null
+# the real loadtest
+cat $targets_file | vegeta attack -http2 -duration=${duration}s -rate=0 -max-workers=${workers} > data/$project_bin
 cat data/$project_bin | vegeta report > data/$project_report
 rm data/$project_bin
 

--- a/diesel-rocket/src/db.rs
+++ b/diesel-rocket/src/db.rs
@@ -20,8 +20,8 @@ impl Db {
         let db_url = env::var("DATABASE_URL")?;
         let manager = r2d2::ConnectionManager::new(db_url);
         let pool = r2d2::Builder::new()
-            .max_size(100)
-            .min_idle(Some(50))
+            .max_size(20)
+            .min_idle(Some(10))
             .build(manager)?;
         Ok(Db { pool })
     }

--- a/sqlx-actix-web/src/db.rs
+++ b/sqlx-actix-web/src/db.rs
@@ -12,8 +12,8 @@ impl Db {
     pub async fn connect() -> Result<Self, StdErr> {
         let db_url = std::env::var("DATABASE_URL")?;
         let pool = PgPoolOptions::new()
-            .max_connections(100)
-            .min_connections(50)
+            .max_connections(20)
+            .min_connections(10)
             .connect(&db_url)
             .await?;
         Ok(Db { pool })


### PR DESCRIPTION
- I enabled http2 and also added a 10 sec warmup (for all tests) to also spin up the modern desktop CPUs.
- Also lowered the number of connections to DB, because 50 and 100 will slow down the DB!

With the above changes, on an i7 (8 CPU / 4 core) and 16MB ram (Linux), I've achieved 978488 total req for SA Read, and 76799 SA Mixed.

I couldn't test other envs, anyway I did the same change for DR.